### PR TITLE
fix watch to properly pass port variable to browsersync opts

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,5 @@
 module.exports = function (Spike, args) {
-  const project = new Spike({ root: args.path, env: args.env, server: { port: args.port }})
+  const project = new Spike({ root: args.path, env: args.env, server: { port: args.port } })
   process.nextTick(() => project.watch())
   return project
 }

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,5 @@
 module.exports = function (Spike, args) {
-  const project = new Spike({ root: args.path, env: args.env })
+  const project = new Spike({ root: args.path, env: args.env, server: { port: args.port }})
   process.nextTick(() => project.watch())
   return project
 }

--- a/test/index.js
+++ b/test/index.js
@@ -121,6 +121,7 @@ test.cb('watch', (t) => {
   cli.on('warning', t.end)
   cli.on('compile', (res) => {
     t.is(res, 'watch mock')
+    t.falsy(mock.opts.server.port)
     t.end()
   })
 
@@ -136,6 +137,17 @@ test.cb('watch with env option', (t) => {
   })
 
   cli.run('watch -e production')
+})
+
+test.cb('watch with port option', (t) => {
+  cli.on('error', t.end)
+  cli.on('warning', t.end)
+  cli.on('compile', (res) => {
+    t.is(mock.opts.server.port, 1118)
+    t.end()
+  })
+
+  cli.run('watch -p 1118')
 })
 
 test.cb('add', (t) => {


### PR DESCRIPTION
I have changed `lib/watch.js` to properly pass the `port` variable from the command line through to browsersync. 