### PR TITLE
Prefer Local Spike Install

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,10 @@ const GA = require('universal-analytics')
 const ArgumentParser = require('argparse').ArgumentParser
 const reduce = require('lodash.reduce')
 const pkg = require('../package.json')
-let Spike = require('spike-core') // mocked in tests
+const path = require('path')
+const fs = require('fs')
 let analytics
+let Spike
 
 /**
  * @class CLI
@@ -18,9 +20,6 @@ let analytics
 module.exports = class CLI extends EventEmitter {
   constructor () {
     super()
-
-    const uid = Spike.globalConfig().id // mocked in tests
-    analytics = new GA('UA-79663181-1', uid, { strictCidFormat: false })
 
     this.parser = new ArgumentParser({
       version: pkg.version,
@@ -49,6 +48,20 @@ module.exports = class CLI extends EventEmitter {
     // argparse uses `null` which doesn't get along with joi, so we remove
     // null values here
     args = reduce(args, (m, v, k) => { if (v) m[k] = v; return m }, {})
+
+    // try to load up a local spike instance first
+    let spikePath = args.path && path.join(args.path, 'node_modules/spike-core')
+    try {
+      fs.accessSync(spikePath)
+    } catch (_) {
+      spikePath = 'spike-core'
+    }
+
+    if (!Spike) { Spike = require(spikePath) }
+
+    // set up analytics
+    const uid = Spike.globalConfig().id // mocked in tests
+    analytics = new GA('UA-79663181-1', uid, { strictCidFormat: false })
 
     // anonymous analytics for usage data
     analytics.event({ ec: 'cmd', ea: args.fn, ev: JSON.stringify(args) }).send()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chalk": "^2.0.0",
     "inquirer": "^3.2.1",
     "lodash.reduce": "^4.6.0",
-    "spike-core": "^2.1.1",
+    "spike-core": "^2.2.0",
     "universal-analytics": "^0.4.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5217,9 +5217,9 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-spike-core@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/spike-core/-/spike-core-2.1.1.tgz#fd72df1f316ddcd122afe6a6276f710bbe09c561"
+spike-core@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spike-core/-/spike-core-2.2.0.tgz#ace3f6015b30cb84a9250fee42f4418c2fcfea11"
   dependencies:
     babel-core "^6.25.0"
     babel-loader "^7.1.1"
@@ -5240,7 +5240,7 @@ spike-core@^2.1.1:
     source-loader "^1.0.0"
     spike-util "^1.3.0"
     sprout "^1.2.1"
-    webpack "^3.3.0"
+    webpack "^3.4.1"
     when "^3.7.8"
 
 spike-util@^1.3.0:
@@ -5882,9 +5882,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.4.0.tgz#e9465b660ad79dd2d33874d968b31746ea9a8e63"
+webpack@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.4.1.tgz#4c3f4f3fb318155a4db0cb6a36ff05c5697418f4"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
So this is a small and simple change, but one that I think will help to resolve a lot of versioning inconsistencies. It makes it such that if there is a spike-core install in the path the project is being compiled at, the CLI will use that module. This ensures that your local projects will run with the version of spike they are installed with locally, which makes sense.