### PR TITLE
improve error handling

### DIFF
--- a/bin/spike
+++ b/bin/spike
@@ -4,14 +4,15 @@ var chalk = require('chalk')
 var CLI = require('..')
 var cli = new CLI()
 
+const framer = require('code-frame')
+const fs = require('fs')
+
 cli.on('error', function (err) {
-  console.error(chalk.red('✗ ERROR'))
-  console.error(err)
+  console.error(chalk.red('✗ ERROR'), buildMessage(err))
 })
 
 cli.on('warning', function (warn) {
-  console.warn(chalk.yellow('⚠ WARNING'))
-  console.warn(warn)
+  console.warn(chalk.yellow('⚠ WARNING'), buildMessage(warn))
 })
 
 cli.on('compile', function (res) {
@@ -28,3 +29,22 @@ cli.on('info', function (msg) {
 })
 
 cli.run(process.argv.slice(2))
+
+const fileInfoRe = /\/.*\..*\:\d+\:\d+/g
+function buildMessage(err) {
+  let tmp = err.stack.toString().split('\n')
+  let fileInfo = fileInfoRe.exec(tmp[0])
+  if (!fileInfo) fileInfo = fileInfoRe.exec(tmp[1])
+  if (!fileInfo) return err.toString()
+
+  fileInfo = fileInfo[0].split(':')
+  let filepath = fileInfo[0]
+  let line = fileInfo.length > 1 ? parseInt(fileInfo[1], 10) : null
+  let column = fileInfo.length > 2 ? parseInt(fileInfo[2], 10) : null
+
+  let errorInfo = tmp[0].split(': ')
+  let msg = `(${errorInfo[0]}) ${errorInfo[1]}\n`
+  let snippet = framer(fs.readFileSync(filepath, 'utf8'), line, column)
+
+  return `${msg}\n ${fileInfo.join(':')}\n${snippet}`
+}

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,5 +1,5 @@
-module.exports = function(Spike, args) {
-  const project = new Spike({ root: args.path })
+module.exports = function(Spike, { path }) {
+  const project = new Spike({ root: path })
   process.nextTick(() => project.clean())
   return project
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,5 +1,5 @@
-module.exports = function(Spike, args) {
-  const project = new Spike({ root: args.path, env: args.env })
+module.exports = function(Spike, { path, env }) {
+  const project = new Spike({ root: path, env })
   process.nextTick(() => project.compile())
   return project
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events')
 const GA = require('universal-analytics')
 const ArgumentParser = require('argparse').ArgumentParser
 const reduce = require('lodash.reduce')
-const pkg = require('../package.json')
+const { version, description } = require('../package.json')
 const path = require('path')
 const fs = require('fs')
 let analytics
@@ -21,12 +21,7 @@ module.exports = class CLI extends EventEmitter {
   constructor() {
     super()
 
-    this.parser = new ArgumentParser({
-      version: pkg.version,
-      description: pkg.description,
-      addHelp: true
-    })
-
+    this.parser = new ArgumentParser({ version, description, addHelp: true })
     this.sub = this.parser.addSubparsers()
 
     this.addCompile()

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = class CLI extends EventEmitter {
     // try to load up a local spike instance first
     let spikePath = args.path && path.join(args.path, 'node_modules/spike-core')
     try {
-      fs.accessSync(spikePath)
+      fs.accessSync(spikePath, fs.constants.F_OK | fs.constants.R_OK)
     } catch (_) {
       spikePath = 'spike-core'
     }

--- a/lib/new.js
+++ b/lib/new.js
@@ -1,23 +1,23 @@
-const path = require('path')
+const { resolve } = require('path')
 const EventEmitter = require('events').EventEmitter
 const inquirer = require('inquirer')
 
-module.exports = function(Spike, args) {
+module.exports = function(Spike, { path, overrides, template }) {
   const emitter = new EventEmitter()
 
   emitter.on('done', project => {
     emitter.emit(
       'success',
-      `project created at ${path.resolve(project.config.context)}`
+      `project created at ${resolve(project.config.context)}`
     )
   })
 
   process.nextTick(() =>
     Spike.new({
-      root: args.path,
-      emitter: emitter,
-      locals: args.overrides,
-      template: args.template,
+      emitter,
+      template,
+      root: path,
+      locals: overrides,
       inquirer: inquirer.prompt.bind(inquirer)
     })
   )

--- a/lib/template/add.js
+++ b/lib/template/add.js
@@ -2,8 +2,6 @@ const EventEmitter = require('events')
 
 module.exports = function(Spike, args) {
   const emitter = new EventEmitter()
-  process.nextTick(() => {
-    Spike.template.add(Object.assign(args, { emitter: emitter }))
-  })
+  process.nextTick(() => Spike.template.add(Object.assign(args, { emitter })))
   return emitter
 }

--- a/lib/template/default.js
+++ b/lib/template/default.js
@@ -2,8 +2,8 @@ const EventEmitter = require('events')
 
 module.exports = function(Spike, args) {
   const emitter = new EventEmitter()
-  process.nextTick(() => {
-    Spike.template.default(Object.assign(args, { emitter: emitter }))
-  })
+  process.nextTick(() =>
+    Spike.template.default(Object.assign(args, { emitter }))
+  )
   return emitter
 }

--- a/lib/template/list.js
+++ b/lib/template/list.js
@@ -4,10 +4,10 @@ module.exports = function(Spike, args) {
   const emitter = new EventEmitter()
   const e2 = new EventEmitter()
   process.nextTick(() => {
-    emitter.on('success', res => {
+    emitter.on('success', res =>
       e2.emit('success', 'Your Templates:\n- ' + Object.keys(res).join('\n- '))
-    })
-    Spike.template.list(Object.assign(args, { emitter: emitter }))
+    )
+    Spike.template.list(Object.assign(args, { emitter }))
   })
   return e2
 }

--- a/lib/template/remove.js
+++ b/lib/template/remove.js
@@ -2,8 +2,8 @@ const EventEmitter = require('events')
 
 module.exports = function(Spike, args) {
   const emitter = new EventEmitter()
-  process.nextTick(() => {
-    Spike.template.remove(Object.assign(args, { emitter: emitter }))
-  })
+  process.nextTick(() =>
+    Spike.template.remove(Object.assign(args, { emitter }))
+  )
   return emitter
 }

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,9 +1,5 @@
-module.exports = function(Spike, args) {
-  const project = new Spike({
-    root: args.path,
-    env: args.env,
-    server: { port: args.port }
-  })
+module.exports = function(Spike, { path, env, port }) {
+  const project = new Spike({ env, root: path, server: { port } })
   process.nextTick(() => project.watch())
   return project
 }


### PR DESCRIPTION
this is based on #82 

- Improves error handling

### Caveats
- Reshape errors display parsing errors, from reshape core, rather than the Error w/`file:line:column`. This pull request does not fix this issue, the fix will have to be completed in Reshape itself.
- Postcss/Babel errors are displayed as "WARNINGS" (no clue as to why)

### Previews
> NOTE: Project names were redacted.

#### Postcss Error
![1513016309663](https://user-images.githubusercontent.com/2363940/33846723-042abb50-de76-11e7-9259-1c4e36b70751.jpg)

####  DatoCMS (`app.js`) Error
![1513016619565](https://user-images.githubusercontent.com/2363940/33846894-aeff17b0-de76-11e7-8efc-226b64a1bcf3.jpg)